### PR TITLE
Use Hugging Face endpoint for agent model

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,4 +1,6 @@
-from langchain_huggingface import ChatHuggingFace
+import os
+
+from langchain_huggingface import ChatHuggingFace, HuggingFaceEndpoint
 from langchain.tools import tool
 from langgraph.prebuilt import create_react_agent
 from dotenv import load_dotenv
@@ -18,7 +20,17 @@ def say_hello(name: str) -> str:
 
 def create_agent():
     """Create and return the ReAct agent executor."""
-    model = ChatHuggingFace(repo_id="mistralai/Mistral-7B-Instruct", temperature=0)
+    if not os.getenv("HUGGINGFACEHUB_API_TOKEN"):
+        raise EnvironmentError(
+            "A valid Hugging Face token must be available in the environment, e.g. "
+            "HUGGINGFACEHUB_API_TOKEN."
+        )
+
+    endpoint = HuggingFaceEndpoint(
+        repo_id="mistralai/Mistral-7B-Instruct",
+        temperature=0,
+    )
+    model = ChatHuggingFace(llm=endpoint)
     tools = [calculator, say_hello]
     agent_executor = create_react_agent(model, tools)
     return agent_executor


### PR DESCRIPTION
## Summary
- switch the agent model setup to use a Hugging Face endpoint wrapper
- validate that a Hugging Face access token is available before constructing the model

## Testing
- not run

